### PR TITLE
Add React frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # WebCustomForm
-App web che visualizza tabelle in base a configurazione json
+
+Front-end React application consuming a FastAPI backend.
+
+## Setup
+
+```bash
+cd frontend
+npm install
+npm run dev
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebCustomForm</title>
+  </head>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "webcustomform-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.4.0",
+    "zustand": "^4.4.0",
+    "zod": "^3.23.0",
+    "ag-grid-community": "^30.1.0",
+    "ag-grid-react": "^30.1.0",
+    "recharts": "^2.7.2",
+    "@radix-ui/react-dropdown-menu": "^1.0.5"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,29 @@
+import QuerySelect from './components/QuerySelect';
+import ParamsForm from './components/ParamsForm';
+import TableView from './components/DataView/TableView';
+import GridSettingsDrawer from './components/GridSettingsDrawer';
+import ConfigEditorDialog from './components/ConfigEditorDialog/ConfigEditorDialog';
+import useStore from './store';
+import { useEffect } from 'react';
+
+function App() {
+  const fetchQueries = useStore(s => s.fetchQueries);
+  useEffect(() => {
+    fetchQueries();
+  }, [fetchQueries]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <header className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">WebCustomForm</h1>
+        <ConfigEditorDialog />
+      </header>
+      <QuerySelect />
+      <ParamsForm />
+      <TableView />
+      <GridSettingsDrawer />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:8001',
+});
+
+api.interceptors.response.use(
+  res => res,
+  err => {
+    console.error(err);
+    return Promise.reject(err);
+  }
+);
+
+export default api;

--- a/frontend/src/components/ConfigEditorDialog/ConfigEditorDialog.tsx
+++ b/frontend/src/components/ConfigEditorDialog/ConfigEditorDialog.tsx
@@ -1,0 +1,5 @@
+export default function ConfigEditorDialog() {
+  return (
+    <button className="px-2 py-1 border">Edit Config</button>
+  );
+}

--- a/frontend/src/components/ConfigEditorDialog/ConfigTabs.tsx
+++ b/frontend/src/components/ConfigEditorDialog/ConfigTabs.tsx
@@ -1,0 +1,3 @@
+export default function ConfigTabs() {
+  return <div>Config tabs placeholder</div>;
+}

--- a/frontend/src/components/DataView/ChartView.tsx
+++ b/frontend/src/components/DataView/ChartView.tsx
@@ -1,0 +1,21 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import useStore from '../../store';
+
+export default function ChartView() {
+  const results = useStore(s => s.results);
+  if (results.length === 0) return null;
+  const data = results;
+  const keys = Object.keys(data[0]);
+  const [x, y1, y2] = keys;
+  return (
+    <LineChart width={500} height={300} data={data}>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey={x} />
+      <YAxis />
+      <Tooltip />
+      <Legend />
+      {y1 && <Line type="monotone" dataKey={y1} stroke="#8884d8" />}
+      {y2 && <Line type="monotone" dataKey={y2} stroke="#82ca9d" />}
+    </LineChart>
+  );
+}

--- a/frontend/src/components/DataView/PivotView.tsx
+++ b/frontend/src/components/DataView/PivotView.tsx
@@ -1,0 +1,4 @@
+// Placeholder for pivot view using AG Grid pivot mode
+export default function PivotView() {
+  return <div>Pivot view not implemented</div>;
+}

--- a/frontend/src/components/DataView/TableView.tsx
+++ b/frontend/src/components/DataView/TableView.tsx
@@ -1,0 +1,20 @@
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import useStore from '../../store';
+
+function TableView() {
+  const results = useStore(s => s.results);
+
+  if (results.length === 0) return null;
+
+  const columns = Object.keys(results[0]).map(field => ({ field }));
+
+  return (
+    <div className="ag-theme-alpine" style={{ height: 400, width: '100%' }}>
+      <AgGridReact rowData={results} columnDefs={columns} />
+    </div>
+  );
+}
+
+export default TableView;

--- a/frontend/src/components/GridSettingsDrawer.tsx
+++ b/frontend/src/components/GridSettingsDrawer.tsx
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+import useStore from '../store';
+
+export default function GridSettingsDrawer() {
+  const [open, setOpen] = useState(false);
+  const styles = useStore(s => s.styles);
+
+  return (
+    <div>
+      <button className="px-2 py-1 border" onClick={() => setOpen(!open)}>Grid Settings</button>
+      {open && (
+        <div className="fixed right-0 top-0 w-64 h-full bg-white shadow p-4">
+          <pre className="text-xs">{JSON.stringify(styles, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ParamsForm.tsx
+++ b/frontend/src/components/ParamsForm.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { z } from 'zod';
+import useStore from '../store';
+
+function ParamsForm() {
+  const selected = useStore(s => s.selected);
+  const runQuery = useStore(s => s.runQuery);
+  const [values, setValues] = useState<Record<string, any>>({});
+
+  if (!selected?.parameters || selected.parameters.length === 0) return null;
+
+  const visibleParams = selected.parameters.filter(p => p.visible);
+  const schema = z.object(Object.fromEntries(visibleParams.map(p => [p.name, z.any()])));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = schema.safeParse(values);
+    if (parsed.success) runQuery(parsed.data);
+  };
+
+  return (
+    <form className="space-y-2" onSubmit={handleSubmit}>
+      {visibleParams.map(p => (
+        <div key={p.name} className="flex flex-col">
+          <label className="text-sm">{p.description || p.name}</label>
+          <input
+            className="p-2 border rounded"
+            value={values[p.name] ?? ''}
+            onChange={e => setValues({ ...values, [p.name]: e.target.value })}
+          />
+        </div>
+      ))}
+      <button className="px-4 py-2 bg-blue-500 text-white rounded" type="submit">Run</button>
+    </form>
+  );
+}
+
+export default ParamsForm;

--- a/frontend/src/components/QuerySelect.tsx
+++ b/frontend/src/components/QuerySelect.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import useStore from '../store';
+
+function QuerySelect() {
+  const { queries, selected } = useStore();
+  const setSelected = useStore(s => (q: any) => s.selected = q);
+
+  return (
+    <select
+      className="p-2 border rounded"
+      value={selected?.name || ''}
+      onChange={e => {
+        const q = queries.find(q => q.name === e.target.value);
+        if (q) setSelected(q);
+      }}
+    >
+      <option value="">Select Query</option>
+      {queries.map(q => (
+        <option key={q.name} value={q.name}>{q.name}</option>
+      ))}
+    </select>
+  );
+}
+
+export default QuerySelect;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,0 +1,30 @@
+import create from 'zustand';
+import { Query } from '../types';
+import api from '../api/client';
+
+interface State {
+  queries: Query[];
+  selected?: Query;
+  results: any[];
+  styles: any;
+  fetchQueries: () => Promise<void>;
+  runQuery: (params: Record<string, any>) => Promise<void>;
+}
+
+const useStore = create<State>((set, get) => ({
+  queries: [],
+  results: [],
+  styles: {},
+  async fetchQueries() {
+    const { data } = await api.get<Query[]>('/api/queries');
+    set({ queries: data });
+  },
+  async runQuery(params) {
+    const sel = get().selected;
+    if (!sel) return;
+    const { data } = await api.post(`/api/query/${encodeURIComponent(sel.name)}`, params);
+    set({ results: data });
+  }
+}));
+
+export default useStore;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,16 @@
+export interface QueryParam {
+  name: string;
+  type: string;
+  required: boolean;
+  description?: string;
+  default?: any;
+  visible: boolean;
+}
+
+export interface Query {
+  name: string;
+  type: string;
+  description: string;
+  query: string;
+  parameters?: QueryParam[] | null;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add React + Vite frontend scaffolding with Tailwind
- basic zustand store, query selection and simple AG Grid table
- minimal placeholder components for config editor and grid settings
- instructions to install and run

## Testing
- `git status --short`